### PR TITLE
RFC: Redefine PlotTheme struct to accept any Plots attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 0.6
   - nightly
 matrix:
   allow_failures:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5
+julia 0.6
 PlotUtils 0.4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/PlotThemes.jl
+++ b/src/PlotThemes.jl
@@ -5,49 +5,44 @@ module PlotThemes
 using PlotUtils
 
 export
-    add_theme
+    add_theme, palette
 
 _255_to_1(c::Symbol, colors) = RGBA(map(x-> x/255,colors[c])...)
 RGB255(r,g,b) = RGB(r/255, g/255, b/255)
 expand_palette(bg, palette; kwargs...) = [convert(RGBA,c) for c in  distinguishable_colors(20, vcat(bg, palette); kwargs...)][2:end]
 
+const KW = Dict{Symbol, Any}
+
 immutable PlotTheme
-    bg_primary
-    bg_secondary
-    lines
-    text
-    palette
-    gradient
+    defaults::KW
 end
 
-# by default we don't change the gradient
-function PlotTheme(bg_primary, bg_secondary, lines, text, palette)
-    PlotTheme(bg_primary, bg_secondary, lines, text, palette, nothing)
-end
+PlotTheme(; kw...) = PlotTheme(KW(kw))
 
 # adjust an existing theme
-function PlotTheme(base::PlotTheme;
-                    bg_primary = base.bg_primary,
-                    bg_secondary = base.bg_secondary,
-                    lines = base.lines,
-                    text = base.text,
-                    palette = base.palette,
-                    gradient = base.gradient
-                   )
-    PlotTheme(bg_primary, bg_secondary, lines, text, palette, gradient)
+PlotTheme(base::PlotTheme; kw...) = PlotTheme(KW(base.defaults..., KW(kw)...))
+
+"Get the palette of a PlotTheme"
+function palette(s::Symbol)
+    if haskey(_themes, s) && haskey(_themes[s].defaults, :palette)
+        return _themes[s].defaults[:palette]
+    else
+        return get_color_palette(:auto, plot_color(:white), 17)
+    end
 end
 
-const _themes = Dict{Symbol, PlotTheme}()
+const _themes = Dict{Symbol, PlotTheme}(:default => PlotTheme())
 
 gradient_name(s::Symbol) = Symbol(s, "_grad")
 
 function add_theme(s::Symbol, thm::PlotTheme)
-    if thm.gradient != nothing
-        PlotUtils.register_gradient_colors(gradient_name(s), thm.gradient, :misc)
+    if haskey(thm.defaults, :gradient)
+        PlotUtils.register_gradient_colors(gradient_name(s), thm.defaults[:gradient], :misc)
     end
     _themes[s] = thm
 end
 
+# add themes
 include("dark.jl")
 include("ggplot2.jl")
 include("solarized.jl")
@@ -55,6 +50,7 @@ include("sand.jl")
 include("lime.jl")
 include("orange.jl")
 include("juno.jl")
+include("colorblind.jl")
 
 function __init__()
     # need to do this here so PlotUtils picks up the change

--- a/src/PlotThemes.jl
+++ b/src/PlotThemes.jl
@@ -13,7 +13,7 @@ expand_palette(bg, palette; kwargs...) = [convert(RGBA,c) for c in  distinguisha
 
 const KW = Dict{Symbol, Any}
 
-immutable PlotTheme
+struct PlotTheme
     defaults::KW
 end
 

--- a/src/PlotThemes.jl
+++ b/src/PlotThemes.jl
@@ -50,7 +50,7 @@ include("sand.jl")
 include("lime.jl")
 include("orange.jl")
 include("juno.jl")
-include("colorblind.jl")
+include("wong.jl")
 
 function __init__()
     # need to do this here so PlotUtils picks up the change

--- a/src/PlotThemes.jl
+++ b/src/PlotThemes.jl
@@ -33,7 +33,7 @@ end
 
 const _themes = Dict{Symbol, PlotTheme}(:default => PlotTheme())
 
-gradient_name(s::Symbol) = Symbol(s, "_grad")
+gradient_name(s::Symbol) = s == :default ? :inferno : Symbol(s, "_grad")
 
 function add_theme(s::Symbol, thm::PlotTheme)
     if haskey(thm.defaults, :gradient)

--- a/src/colorblind.jl
+++ b/src/colorblind.jl
@@ -1,0 +1,16 @@
+# colors chosen by according to https://www.nature.com/articles/nmeth.1618?WT.ec_id=NMETH-201106
+# as proposed by @tpoisot in https://github.com/JuliaPlots/Plots.jl/issues/1144
+const colorblind_palette = [
+    RGB(([230, 159,   0] / 255)...), # orange
+    RGB(([ 86, 180, 233] / 255)...), # sky blue
+    RGB(([  0, 158, 115] / 255)...), # blueish green
+    RGB(([240, 228,  66] / 255)...), # yellow
+    RGB(([  0, 114, 178] / 255)...), # blue
+    RGB(([213,  94,   0] / 255)...), # vermillion
+    RGB(([204, 121, 167] / 255)...), # reddish purple
+    ]
+
+_themes[:colorblind] = PlotTheme(
+    palette = expand_palette(colorant"white", colorblind_palette; lchoices=linspace(57,57,1), cchoices=linspace(100,100,1)),
+    gradient = colorblind_palette[[2, 1]]
+)

--- a/src/dark.jl
+++ b/src/dark.jl
@@ -8,11 +8,13 @@ dark_palette = [
 dark_bg = colorant"#363D46"
 
 _themes[:dark] = PlotTheme(
-    dark_bg,
-    colorant"#30343B",
-    colorant"#ADB2B7",
-    colorant"#FFFFFF",
-    expand_palette(dark_bg, dark_palette; lchoices=linspace(57,57,1),
+    bg = dark_bg,
+    bginside = colorant"#30343B",
+    fg = colorant"#ADB2B7",
+    fgtext = colorant"#FFFFFF",
+    fgguide = colorant"#FFFFFF",
+    fglegend = colorant"#FFFFFF",
+    palette = expand_palette(dark_bg, dark_palette; lchoices=linspace(57,57,1),
                                           cchoices=linspace(100,100,1)),
-    dark_palette[[2,1]]
+    gradient = dark_palette[[2,1]]
 )

--- a/src/ggplot2.jl
+++ b/src/ggplot2.jl
@@ -22,3 +22,15 @@
 #           fgtext   = :lightgray,
 #           fglegend = :lightgray,
 #           fgguide  = :black)
+
+_themes[:ggplot2] = PlotTheme(
+    bg = :white,
+    bginside = :lightgray,
+    bglegend = plot_color(:lightgray, 0.8),
+    framestyle = :grid,
+    gridcolor = :white,
+    gridalpha = 1,
+    fgtext = :grey,
+    fglegend = :white,
+    fgguide = :black,
+)

--- a/src/juno.jl
+++ b/src/juno.jl
@@ -8,11 +8,13 @@ juno_palette = [
 juno_bg = colorant"#282C34"
 
 _themes[:juno] = PlotTheme(
-    juno_bg,
-    colorant"#21252B",
-    colorant"#ADB2B7",
-    colorant"#9EB1BE",
-    expand_palette(juno_bg, juno_palette; lchoices=linspace(57,57,1),
+    bg = juno_bg,
+    bginside = colorant"#21252B",
+    fg = colorant"#ADB2B7",
+    fgtext = colorant"#9EB1BE",
+    fgguide = colorant"#9EB1BE",
+    fglegend = colorant"#9EB1BE",
+    palette = expand_palette(juno_bg, juno_palette; lchoices=linspace(57,57,1),
                                           cchoices=linspace(100,100,1)),
-    dark_palette[[2,1]]
+    gradient = dark_palette[[2,1]]
 )

--- a/src/lime.jl
+++ b/src/lime.jl
@@ -9,10 +9,12 @@ const lime_palette = reverse([colorant"#271924", # dark blue
 black = lime_palette[6]
 
 _themes[:lime] = PlotTheme(
-    black,
-    black,
-    lime_palette[1],
-    lime_palette[2],
-    expand_palette(black, lime_palette[1:4]),
-    lime_palette
+    bg = black,
+    bginside = black,
+    fg = lime_palette[1],
+    fgtext = lime_palette[2],
+    fgguide = lime_palette[2],
+    fglegend = lime_palette[2],
+    palette = expand_palette(black, lime_palette[1:4]),
+    gradient = lime_palette
 )

--- a/src/orange.jl
+++ b/src/orange.jl
@@ -10,10 +10,12 @@ orange_palette =  reverse([
 black = orange_palette[5]
 
 _themes[:orange] = PlotTheme(
-    black,
-    black,
-    orange_palette[1],
-    orange_palette[2],
-    expand_palette(black, orange_palette[1:4]),
-    orange_palette[1:4]
+    bg = black,
+    bginside = black,
+    fg = orange_palette[1],
+    fgtext = orange_palette[2],
+    fgguide = orange_palette[2],
+    fglegend = orange_palette[2],
+    palette = expand_palette(black, orange_palette[1:4]),
+    gradient = orange_palette[1:4]
 )

--- a/src/sand.jl
+++ b/src/sand.jl
@@ -11,10 +11,12 @@ const sand_palette = [
 sand_bg = colorant"#F7F3EE"
 
 _themes[:sand] = PlotTheme(
-    sand_bg,
-    colorant"#E2DCD4",
-    colorant"#CBBFAF",
-    colorant"#725B61",
-    expand_palette(sand_bg, sand_palette),
-    sand_palette[[1,4]]
+    bg = sand_bg,
+    bginside = colorant"#E2DCD4",
+    fg = colorant"#CBBFAF",
+    fgtext = colorant"#725B61",
+    fgguide = colorant"#725B61",
+    fglegend = colorant"#725B61",
+    palette = expand_palette(sand_bg, sand_palette),
+    gradient = sand_palette[[1,4]]
 )

--- a/src/solarized.jl
+++ b/src/solarized.jl
@@ -21,19 +21,23 @@ const _solarized_colors = Dict(
 )
 
 _themes[:solarized] = PlotTheme(
-    _solarized_colors[:base03],
-    _solarized_colors[:base02],
-    _solarized_colors[:base00],
-    _solarized_colors[:base01],
-    expand_palette(_solarized_colors[:base03], [_solarized_colors[c] for c in _solarized_palette]),
-    [_solarized_colors[:yellow], _solarized_colors[:orange], _solarized_colors[:red]]
+    bg = _solarized_colors[:base03],
+    bginside = _solarized_colors[:base02],
+    fg = _solarized_colors[:base00],
+    fgtext = _solarized_colors[:base01],
+    fgguide = _solarized_colors[:base01],
+    fglegend = _solarized_colors[:base01],
+    palette = expand_palette(_solarized_colors[:base03], [_solarized_colors[c] for c in _solarized_palette]),
+    gradient = [_solarized_colors[:yellow], _solarized_colors[:orange], _solarized_colors[:red]]
 )
 
 _themes[:solarized_light] = PlotTheme(
-    _solarized_colors[:base3],
-    _solarized_colors[:base2],
-    _solarized_colors[:base0],
-    _solarized_colors[:base1],
-    expand_palette(_solarized_colors[:base3], [_solarized_colors[c] for c in _solarized_palette]),
-    [_solarized_colors[:yellow], _solarized_colors[:orange], _solarized_colors[:red]]
+    bg = _solarized_colors[:base3],
+    bginside = _solarized_colors[:base2],
+    fg = _solarized_colors[:base0],
+    fgtext = _solarized_colors[:base1],
+    fgguide = _solarized_colors[:base1],
+    fglegend = _solarized_colors[:base1],
+    palette = expand_palette(_solarized_colors[:base3], [_solarized_colors[c] for c in _solarized_palette]),
+    gradient = [_solarized_colors[:yellow], _solarized_colors[:orange], _solarized_colors[:red]]
 )

--- a/src/wong.jl
+++ b/src/wong.jl
@@ -1,6 +1,6 @@
 # colors chosen by according to https://www.nature.com/articles/nmeth.1618?WT.ec_id=NMETH-201106
 # as proposed by @tpoisot in https://github.com/JuliaPlots/Plots.jl/issues/1144
-const colorblind_palette = [
+const wong_palette = [
     RGB(([230, 159,   0] / 255)...), # orange
     RGB(([ 86, 180, 233] / 255)...), # sky blue
     RGB(([  0, 158, 115] / 255)...), # blueish green
@@ -10,7 +10,7 @@ const colorblind_palette = [
     RGB(([204, 121, 167] / 255)...), # reddish purple
     ]
 
-_themes[:colorblind] = PlotTheme(
-    palette = expand_palette(colorant"white", colorblind_palette; lchoices=linspace(57,57,1), cchoices=linspace(100,100,1)),
-    gradient = colorblind_palette[[2, 1]]
+_themes[:wong] = PlotTheme(
+    palette = expand_palette(colorant"white", wong_palette; lchoices=linspace(57,57,1), cchoices=linspace(100,100,1)),
+    gradient = wong_palette[[2, 1]]
 )

--- a/src/wong.jl
+++ b/src/wong.jl
@@ -12,5 +12,5 @@ const wong_palette = [
 
 _themes[:wong] = PlotTheme(
     palette = expand_palette(colorant"white", wong_palette; lchoices=linspace(57,57,1), cchoices=linspace(100,100,1)),
-    gradient = wong_palette[[2, 1]]
+    gradient = cgrad(:viridis).colors,
 )


### PR DESCRIPTION
This changes `PlotTheme` to
```julia
struct PlotTheme
    defaults::KW
end
```
where `const KW = Dict{Symbol, Any}`. This allows to pass any Plots attribute to a `PlotTheme` in general, as discussed in https://github.com/JuliaPlots/Plots.jl/issues/5627
`PlotTheme`s can be either constructed with the default constructor `PlotTheme(kw::KW)` or via `PlotTheme(; kw...)`

All existing themes have been adjusted to match the new syntax and two new themes have been added:
* A first attempt of **:ggplot2**:
![plottheme_ggplot2](https://user-images.githubusercontent.com/16589944/33557124-a0016ec2-d906-11e7-9632-238f392cfe79.png)

* A first attempt of a **:colorblind** theme based on the colors proposed by @tpoisot in https://github.com/JuliaPlots/Plots.jl/issues/1144:
![plottheme_colorblind](https://user-images.githubusercontent.com/16589944/33557200-e21a709c-d906-11e7-8d7c-fd1e5e3974f7.png)

Furthermore, this exports the function `palette(s::Symbol)` which returns the palette of a `PlotTheme` and lets the user do something like `theme(:ggplot2, palette = palette(:colorblind)`, i.e. using the ggplot2 theme with the palette of colorblind.

Most importantly this requires https://github.com/JuliaPlots/Plots.jl/pull/1279 and vice versa. I'm not sure what the best release strategy would look like.