### PR TITLE
Improving ggplot2 theme

### DIFF
--- a/src/ggplot2.jl
+++ b/src/ggplot2.jl
@@ -23,14 +23,42 @@
 #           fglegend = :lightgray,
 #           fgguide  = :black)
 
+const _ggplot_colors = Dict(
+    :gray92 => RGB(fill(0.92, 3)...),
+    :gray20 => RGB(fill(0.2, 3)...),
+    :gray30 => RGB(fill(0.3, 3)...)
+    )
+
+
 _themes[:ggplot2] = PlotTheme(
+    ## Background etc
     bg = :white,
-    bginside = :lightgray,
-    bglegend = plot_color(:lightgray, 0.8),
-    framestyle = :grid,
-    gridcolor = :white,
-    gridalpha = 1,
-    fgtext = :grey,
+    bginside = _ggplot_colors[:gray92],
+    bglegend = _ggplot_colors[:gray92],
     fglegend = :white,
     fgguide = :black,
-)
+    widen=true,
+    ## Axes / Ticks
+    #framestyle = :grid,
+    #foreground_color_tick = _ggplot_colors[:gray20], # tick color not yet implemented
+    foreground_color_axis = _ggplot_colors[:gray20], # tick color
+    tick_direction=:out,
+    foreground_color_border =:white, # axis color
+    foreground_color_text = _ggplot_colors[:gray30], # tick labels
+    gridlinewidth = 1,
+    #tick label size = *0.8,
+    ### Grid
+    foreground_color_grid = :white,
+    gridalpha = 1,
+    ### Minor Grid
+    minorgrid = true,
+    minorgridalpha = 1,
+    minorgridlinewidth=0.5, # * 0.5
+    foreground_color_minor_grid=:white,
+    #foreground_color_minortick=:white, ## not yet implemented
+    minorticks = 2,
+    ## Lines and markers
+    markerstrokealpha = 0,
+    markerstrokewidth = 0
+    #showaxis= :false
+    )


### PR DESCRIPTION
I would like to improve the ggplot2 theme.

This is the first step.

Old `:gglot2` (`pyplot()`)
![scatter_gr_old](https://user-images.githubusercontent.com/6280307/46473784-82c02680-c7e1-11e8-8bf5-914b10168a98.png)

New `:ggplot2` (`pyplot()`)
![scatter_py](https://user-images.githubusercontent.com/6280307/46473997-10037b00-c7e2-11e8-8136-b9ade5aae8cb.png)

Main differences
1. added 'outside ticks' 
2. no lines around markers _(EDIT: added this bullet)_
3. lighter gray background. I tried to match the shades of gray according to 
```R
R> library("ggplot2")
R> theme_get()
```
Does someone know the `Julia`equivalent of `grey30`, `grey90`, etc? I translated it to `grey$x == plot_color(:black, 1 - x)`.

Actual `ggplot2`
![scatter_gg](https://user-images.githubusercontent.com/6280307/46473800-8c498e80-c7e1-11e8-9617-915bef4ed612.png)

Unfortunately, it is not equally nice on all backends. 

- A problem is that often setting axes and ticks independently is not possible
 (axis color = white and tick color = gray)

Still missing: 

1. adding minor gridlines but no minor ticks (cannot be controlled independently)
2. adding minor gridlines at all doesn't seem to be supported for some backends
3. removing the axis altogether to remove the gap between grid and outside tick

Note: the file in the test folder will be removed eventually. I will just keep it as long as I am working on this.