### PR TITLE
Dark Theme - Set more font colors to white

### DIFF
--- a/src/dark.jl
+++ b/src/dark.jl
@@ -14,6 +14,9 @@ _themes[:dark] = PlotTheme(
     fgtext = colorant"#FFFFFF",
     fgguide = colorant"#FFFFFF",
     fglegend = colorant"#FFFFFF",
+    legendfontcolor = colorant"#FFFFFF",
+    legendtitlefontcolor = colorant"#FFFFFF",
+    titlefontcolor = colorant"#FFFFFF",
     palette = expand_palette(dark_bg, dark_palette; lchoices = [57], cchoices = [100]),
     colorgradient = cgrad(:fire).colors
 )


### PR DESCRIPTION
Many font colours are left as `match` which produces very poor contrast:

![default-grey-text](https://user-images.githubusercontent.com/13415723/72923087-38501980-3d46-11ea-8d4e-13ab52c728e1.png)

By specifying them as white the contrast is much better:
![white-text](https://user-images.githubusercontent.com/13415723/72923130-5158ca80-3d46-11ea-9368-a7dab958df49.png)