### PR TITLE
A new theme (:dao)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Currently the following themes are available:
 - `:bright`
 - `:vibrant`
 - `:mute`
+- `:dao`
+
 
 When using Plots, a theme can be set using the `theme` function:
 ```julia
@@ -86,6 +88,10 @@ Themes can be previewed using `Plots.showtheme(thm::Symbol)`:
 
 ### `:mute`
 ![theme_mute](https://user-images.githubusercontent.com/16589944/70848069-9860bf80-1e6c-11ea-9cac-8a797d526835.png)
+
+
+### `:dao`
+![theme_dao](https://user-images.githubusercontent.com/7330605/106396174-3bbcbd00-63fe-11eb-8cb4-7bade8295b8b.png)
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Themes can be previewed using `Plots.showtheme(thm::Symbol)`:
 
 
 ### `:dao`
-![theme_dao](https://user-images.githubusercontent.com/7330605/106396174-3bbcbd00-63fe-11eb-8cb4-7bade8295b8b.png)
+![theme_dao](https://user-images.githubusercontent.com/7330605/106512313-54de7000-64c9-11eb-98d5-2aee3603879a.png)
 
 
 ## Contributing

--- a/src/PlotThemes.jl
+++ b/src/PlotThemes.jl
@@ -52,6 +52,7 @@ include("wong.jl")
 include("juno.jl")
 include("gruvbox.jl")
 include("sheet.jl")
+include("dao.jl")
 
 function __init__()
     # need to do this here so PlotUtils picks up the change

--- a/src/dao.jl
+++ b/src/dao.jl
@@ -1,0 +1,27 @@
+dao_palette = [
+    colorant"#d77255",
+    colorant"#009afa",
+    colorant"#888",
+    colorant"#333",
+
+]
+
+_themes[:dao] = PlotTheme(
+    bg = :white,
+    framestyle = :box,
+    grid=true,
+    gridalpha=0.4,
+    linewidth=1.2,
+    markerstrokewidth=0,
+    fontfamily = "Computer Modern",
+    colorgradient = :magma,
+    guidefontsize=12,
+    titlefontsize=12,
+    tickfontsize=8,
+    palette = dao_palette,
+    minorgrid=true,
+    minorticks = 5,
+    gridlinewidth = 0.7,
+    minorgridalpha=0.06,
+    legend=:outertopright,
+)

--- a/src/dao.jl
+++ b/src/dao.jl
@@ -1,17 +1,18 @@
 dao_palette = [
     colorant"#d77255",
     colorant"#009afa",
-    colorant"#888",
-    colorant"#333",
-
+    colorant"#707070",
+    colorant"#21ab74",
+    colorant"#ba3030",
+    colorant"#9467bd"
 ]
 
 _themes[:dao] = PlotTheme(
-    bg = :white,
+    background = :white,
     framestyle = :box,
     grid=true,
     gridalpha=0.4,
-    linewidth=1.2,
+    linewidth=1.4,
     markerstrokewidth=0,
     fontfamily = "Computer Modern",
     colorgradient = :magma,
@@ -24,4 +25,5 @@ _themes[:dao] = PlotTheme(
     gridlinewidth = 0.7,
     minorgridalpha=0.06,
     legend=:outertopright,
+    # marker=:auto
 )


### PR DESCRIPTION
Hello,
This PR adds a new Plots theme that resembles the default, but is adjusted to make it more suitable for scientific reports. My goal keep it looking fresh, but a bit more formal.

It switches to a serif font, uses the box framestyle by default, and turns on the minor grid.
It also makes the title font the same size as the guide font size.

Here is the output of `showtheme(:dao)`:
![image](https://user-images.githubusercontent.com/7330605/106396174-3bbcbd00-63fe-11eb-8cb4-7bade8295b8b.png)


<br/>

And here is a standalone plot with a few series:

<img src="https://user-images.githubusercontent.com/7330605/106397394-ffd92600-6404-11eb-8c69-788eac741a1f.png" width=450/>


Currently this assumes the user has the Computer Modern font installed on their computer, though I believe it falls back to the default font if not.

I'm open to suggestions for tweaks!


(note, `showtheme` is currently broken in Plots master, but this PR https://github.com/JuliaPlots/Plots.jl/pull/3267 fixes it) 